### PR TITLE
Your recent change to the format string broke armhf

### DIFF
--- a/src/armsoc_exa.c
+++ b/src/armsoc_exa.c
@@ -264,7 +264,7 @@ ModifyUnAccelPixmapHeader(struct ARMSOCPixmapPrivRec *priv, PixmapPtr pPixmap, i
 		priv->unaccel = malloc(datasize);
 
 		if (!priv->unaccel) {
-			ERROR_MSG("failed to allocate %ld bytes mem",
+			ERROR_MSG("failed to allocate %zu bytes mem",
 					datasize);
 			priv->unaccel_size = 0;
 			return FALSE;


### PR DESCRIPTION
Using %zu in the format string will make it work across both armhf and arm64 architectures.